### PR TITLE
Enabled manual resizing of window.

### DIFF
--- a/ArcDPS Boon Table/AppChart.h
+++ b/ArcDPS Boon Table/AppChart.h
@@ -16,7 +16,7 @@ protected:
 	bool show_subgroups = true;
 	bool show_total = true;
 	bool show_boon_as_progress_bar = true;
-	bool size_to_content = true;
+	//bool size_to_content = true;
 	bool alternating_row_bg = true;
 	ProgressBarColoringMode show_colored = ProgressBarColoringMode::Uncolored;
 	Alignment alignment = Alignment::Right;
@@ -45,7 +45,7 @@ public:
 	void setShowSubgroups(bool new_show);
 	void setShowTotal(bool new_show);
 	void setShowBoonAsProgressBar(bool new_show);
-	void setSizeToContent(bool new_size_to_content);
+	//void setSizeToContent(bool new_size_to_content);
 	void setShowColored(ProgressBarColoringMode new_colored);
 	void setAlternatingRowBg(bool new_alternating_row_bg);
 	void setAlignment(Alignment new_alignment);
@@ -55,7 +55,7 @@ public:
 	[[nodiscard]] bool getShowSubgroups() const;
 	[[nodiscard]] bool bShowTotal() const;
 	[[nodiscard]] bool bShowBoonAsProgressBar() const;
-	[[nodiscard]] bool bSizeToContent() const;
+	//[[nodiscard]] bool bSizeToContent() const;
 	[[nodiscard]] bool bAlternatingRowBg() const;
 	[[nodiscard]] ProgressBarColoringMode getShowColored() const;
 	[[nodiscard]] Alignment getAlignment() const;

--- a/ArcDPS Boon Table/main.cpp
+++ b/ArcDPS Boon Table/main.cpp
@@ -376,8 +376,8 @@ void parseIni()
 	long show_colored = table_ini.GetLongValue("table", "show_colored", static_cast<long>(ProgressBarColoringMode::Uncolored));
 	chart.setShowColored(static_cast<ProgressBarColoringMode>(show_colored));
 
-	bool size_to_content = table_ini.GetBoolValue("table", "size_to_content", true);
-	chart.setSizeToContent(size_to_content);
+	//bool size_to_content = table_ini.GetBoolValue("table", "size_to_content", true);
+	//chart.setSizeToContent(size_to_content);
 
 	bool alternating_row_bg = table_ini.GetBoolValue("table", "alternating_row_bg", true);
 	chart.setAlternatingRowBg(alternating_row_bg);
@@ -395,7 +395,7 @@ void writeIni()
 	rc = table_ini.SetValue("table", "show_total", std::to_string(chart.bShowTotal()).c_str());
 	rc = table_ini.SetValue("table", "show_uptime_as_progress_bar", std::to_string(chart.bShowBoonAsProgressBar()).c_str());
 	rc = table_ini.SetLongValue("table", "show_colored", static_cast<long>(chart.getShowColored()));
-	rc = table_ini.SetBoolValue("table", "size_to_content", chart.bSizeToContent());
+	//rc = table_ini.SetBoolValue("table", "size_to_content", chart.bSizeToContent());
 	rc = table_ini.SetBoolValue("table", "alternating_row_bg", chart.bAlternatingRowBg());
 	rc = table_ini.SetLongValue("table", "alignment", static_cast<long>(chart.getAlignment()));
 


### PR DESCRIPTION
Maybe not a long-term solution, but a hot-fix as current window width is way too large and fixed.

1. Commented everything related to "Always resize window to content" setting as its automatic now.
2. Changed window / table / colums flags to fit given width, and allow user to manualy change it.
3. Height made auto, means window will resize to content each Draw.

Minimum window width can be manualy seted in line 21 of .../AppChart.cpp 
`ImGui::SetNextWindowSizeConstraints(ImVec2( #HERE , -1), ImVec2(FLT_MAX, -1));`

As Name-column is fixed size (fit to user name) it will resize rest of columns if someone, with name, longer than any else, joins group. It may cause a need to resize manualy as other columns will become smaller, so i suggest to set maximum width of Name-column in line 84 of .../AppChart.cpp.
`#HERE, nameColumnId); // TODO: add setting for Maximum Name-column width. Rest can stretch.`

There is no limit to maximum row count / window height. Currently its hard to implement using ScrollX as all Players, Subgroups and Total areas r in same table, so window can still grow (will be my next TODO, if you'll accept changes).

