### PR TITLE
Fix crash on shutdown

### DIFF
--- a/ArcDPS Boon Table/main.cpp
+++ b/ArcDPS Boon Table/main.cpp
@@ -197,7 +197,10 @@ uintptr_t mod_release()
 	// try {
 		settings.saveToFile();
 
-		update_state->FinishPendingTasks();
+		if (update_state)
+		{
+			update_state->FinishPendingTasks();
+		}
 		sequencer.Shutdown();
 		ArcdpsExtension::g_singletonManagerInstance.Shutdown();
 	// } catch(const std::exception& e) {


### PR DESCRIPTION
Fix crash happening on shutdown if `update_state` was not initialized correctly, for example if it was not possible to get the current version of the dll.

This happened to me while doing some tests and `ArcdpsExtension::UpdateChecker::GetCurrentVersion(self_dll)` returned an error, skipping then the `update_state` initialization.