### PR TITLE
Unregister ImGui hooks on dll unload

### DIFF
--- a/ArcDPS Boon Table/BigTable/BigTable.cpp
+++ b/ArcDPS Boon Table/BigTable/BigTable.cpp
@@ -3399,7 +3399,7 @@ namespace ImGuiEx::BigTable {
         ImGui::TextUnformatted(buf);
     }
 
-    void RegisterSettingsHandler(const char* name)
+    void RegisterSettingsHandler(const char* name, void* data)
     {
         ImGuiContext* context = ImGui::GetCurrentContext();
         ImGuiSettingsHandler ini_handler;
@@ -3410,6 +3410,22 @@ namespace ImGuiEx::BigTable {
         ini_handler.ReadLineFn = TableSettingsHandler_ReadLine;
         ini_handler.ApplyAllFn = TableSettingsHandler_ApplyAll;
         ini_handler.WriteAllFn = TableSettingsHandler_WriteAll;
+        ini_handler.UserData = data;
         context->SettingsHandlers.push_back(ini_handler);
+    }
+
+    void UnregisterSettingsHandler(const char* name, void* data)
+    {
+        ImGuiContext* context = ImGui::GetCurrentContext();
+        ImGuiID type_hash = ImHashStr(name);
+
+        for (ImGuiSettingsHandler& handler : context->SettingsHandlers)
+        {
+            if (handler.TypeHash == type_hash && handler.UserData == data)
+            {
+                context->SettingsHandlers.erase(&handler);
+                break;
+            }
+        }
     }
 }

--- a/ArcDPS Boon Table/BigTable/BigTable.h
+++ b/ArcDPS Boon Table/BigTable/BigTable.h
@@ -7,6 +7,7 @@
 #include <imgui/imgui.h>
 #include <imgui/imgui_internal.h>
 #include <ArcdpsExtension/arcdps_structs.h>
+#include <Windows.h>
 
 #define IM_COL32_DISABLE                IM_COL32(0,0,0,1)    // Special sentinel code which cannot be used as a regular color.
 #define IMGUI_TABLE_MAX_COLUMNS         512                 // Arbitrary "safety" maximum, may be lifted in the future if needed. Must fit in ImGuiTableColumnIdx/ImGuiTableDrawChannelIdx.
@@ -286,7 +287,8 @@ namespace ImGuiEx::BigTable {
     ImGuiSortDirection TableGetColumnNextSortDirection(ImGuiTableColumn* column);
     float GetColumnWidth(int column_index = -1);
     void AlignedTextColumn(Alignment alignment, const char* text, ...);
-    void RegisterSettingsHandler(const char* name);
+    void RegisterSettingsHandler(const char* name, void* data);
+    void UnregisterSettingsHandler(const char* name, void* data);
     void MenuItemTableColumnVisibility(ImGuiTable* table, int columnIdx);
     ImRect TableGetCellBgRect(const ImGuiTable* table, int column_n);
     int TableGetColumnIndex();

--- a/ArcDPS Boon Table/main.cpp
+++ b/ArcDPS Boon Table/main.cpp
@@ -31,9 +31,9 @@
 /* proto/globals */
 arcdps_exports arc_exports{};
 extern "C" __declspec(dllexport) void* get_init_addr(char* arcversionstr, void* imguicontext, void* dxptr, HMODULE arcdll, void* mallocfn, void* freefn, UINT dxVer);
-extern "C" __declspec(dllexport) void* get_release_addr();
+extern "C" __declspec(dllexport) void* get_release_addr(uint32_t reason);
 arcdps_exports* mod_init();
-uintptr_t mod_release();
+void mod_release();
 UINT mod_wnd(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 void mod_combat(cbtevent* ev, ag* src, ag* dst, const char* skillname, uint64_t id, uint64_t revision);
 void mod_imgui(uint32_t not_charsel_or_loading, uint32_t hide_if_combat_or_ooc); /* id3dd9::present callback, before imgui::render, fn(uint32_t not_charsel_or_loading) */
@@ -107,7 +107,7 @@ extern "C" __declspec(dllexport) void* get_init_addr(char* arcversionstr, void* 
 	ImGui::SetAllocatorFunctions((void* (*)(size_t, void*))mallocfn, (void (*)(void*, void*))freefn);
 
 	// load my table loader into imgui
-	ImGuiEx::BigTable::RegisterSettingsHandler("BigTable-BoonTable");
+	ImGuiEx::BigTable::RegisterSettingsHandler("BigTable-BoonTable", self_dll);
 	static_cast<ImGuiContext*>(imguicontext)->SettingsLoaded = false;
 
 	auto swapChain = static_cast<IDXGISwapChain*>(dxptr);
@@ -117,7 +117,7 @@ extern "C" __declspec(dllexport) void* get_init_addr(char* arcversionstr, void* 
 }
 
 /* export -- arcdps looks for this exported function and calls the address it returns */
-extern "C" __declspec(dllexport) void* get_release_addr() {
+extern "C" __declspec(dllexport) void* get_release_addr(uint32_t reason) {
 	return mod_release;
 }
 
@@ -193,7 +193,7 @@ arcdps_exports* mod_init()
 }
 
 /* release mod -- return ignored */
-uintptr_t mod_release()
+void mod_release()
 {
 	// try {
 		settings.saveToFile();
@@ -204,12 +204,12 @@ uintptr_t mod_release()
 		}
 		sequencer.Shutdown();
 		ArcdpsExtension::g_singletonManagerInstance.Shutdown();
+
+		ImGuiEx::BigTable::UnregisterSettingsHandler("BigTable-BoonTable", self_dll);
 	// } catch(const std::exception& e) {
 	// 	arc_log_file("error in mod_release!");
 	// 	arc_log_file(e.what());
 	// }
-
-	return 0;
 }
 
 /* window callback -- return is assigned to umsg (return zero to not be processed by arcdps or game) */


### PR DESCRIPTION
Unregister ImGui hooks on dll unload to avoid a crash when loading Boon Table twice, unloading the 2nd one and leaving settings hooks in ImGui.

Note that this might cause issues if ImGui context is deleted before Boon Table is unloaded. This could be solved hooking into ImGuiContextHookType_Shutdown.