### PR TITLE
fix: initialize localization language on startup

### DIFF
--- a/ArcDPS Boon Table/main.cpp
+++ b/ArcDPS Boon Table/main.cpp
@@ -139,6 +139,8 @@ arcdps_exports* mod_init()
 		// load translation
 		LoadTranslations();
 
+		ArcdpsExtension::Localization::instance().ChangeLanguage(static_cast<gwlanguage>(settings.getLanguage()));
+
 		// setup icon loader
 		ArcdpsExtension::IconLoader::init(self_dll, id3d11d);
 


### PR DESCRIPTION
Fixes an issue where the extension would read the settings file and load translations on startup, but failed to actually apply the selected language. This resulted in the UI not defaulting to the user's preferred language upon launch.

This PR adds the missing `ChangeLanguage` call immediately after `LoadTranslations()`, ensuring the UI correctly initializes with the language retrieved from `settings.getLanguage()`.