### PR TITLE
Handle hide_if_combat_or_ooc in mod_imgui

### DIFF
--- a/ArcDPS Boon Table/main.cpp
+++ b/ArcDPS Boon Table/main.cpp
@@ -460,7 +460,7 @@ void mod_imgui(uint32_t not_charsel_or_loading, uint32_t hide_if_combat_or_ooc)
 
 		ArcdpsExtension::UpdateChecker::instance().Draw(update_state, "BoonTable", "https://github.com/knoxfighter/GW2-ArcDPS-Boon-Table/releases/latest");
 
-		if (!not_charsel_or_loading) return;
+		if (!not_charsel_or_loading || hide_if_combat_or_ooc) return;
 
 		PRINT_LINE()
 

--- a/ArcDPS Boon Table/main.cpp
+++ b/ArcDPS Boon Table/main.cpp
@@ -460,7 +460,7 @@ void mod_imgui(uint32_t not_charsel_or_loading, uint32_t hide_if_combat_or_ooc)
 
 		ArcdpsExtension::UpdateChecker::instance().Draw(update_state, "BoonTable", "https://github.com/knoxfighter/GW2-ArcDPS-Boon-Table/releases/latest");
 
-		if (!not_charsel_or_loading || hide_if_combat_or_ooc) return;
+		if (!arc_panel_always_draw && (!not_charsel_or_loading || hide_if_combat_or_ooc)) return;
 
 		PRINT_LINE()
 


### PR DESCRIPTION
- Handle hide_if_combat_or_ooc in mod_imgui to follow arcdps settings:
<img width="278" height="139" alt="image" src="https://github.com/user-attachments/assets/c1811036-9955-4038-baa2-a0423d76e0fe" />
- Handle E6 "ui drawn always" option