### PR TITLE
Fix Rite of the Great Dwarf tracking with Versed in Stone

### DIFF
--- a/ArcDPS Boon Table/BuffIds.cpp
+++ b/ArcDPS Boon Table/BuffIds.cpp
@@ -83,7 +83,7 @@ void init_tracked_buffs() {
     tracked_buffs.emplace_back(std::vector<uint32_t>{59592}, BT_BuffInspiringVirtue, StackingType_single, false, BoonType_Guardian, ID_Inspiring_Virtue);
     tracked_buffs.emplace_back(std::vector<uint32_t>{44871}, BT_BuffEternalOasis, StackingType_single, false, BoonType_Guardian, ID_Eternal_Oasis);
     tracked_buffs.emplace_back(std::vector<uint32_t>{43194}, BT_BuffUnbrokenLines, StackingType_single, false, BoonType_Guardian, ID_Unbroken_Lines);
-	tracked_buffs.emplace_back(std::vector<uint32_t>{26596, 33330}, BT_BuffRiteOfTheGreatDwarf, StackingType_single, false, BoonType_Revenant, ID_Rite_of_the_Great_Dwarf);
+	tracked_buffs.emplace_back(std::vector<uint32_t>{26596, 33330, 80245}, BT_BuffRiteOfTheGreatDwarf, StackingType_single, false, BoonType_Revenant, ID_Rite_of_the_Great_Dwarf);
     tracked_buffs.emplace_back(ArcdpsExtension::ET_Unknown); // "Bulwark Gyro (legacy)"
 	tracked_buffs.emplace_back(std::vector<uint32_t>{56890}, BT_BuffSymbolicAvenger, StackingType_single, false, BoonType_Guardian, ID_Symbolic_Avenger);
 	tracked_buffs.emplace_back(std::vector<uint32_t>{30207}, BT_BuffInvigoratedBulwark, StackingType_single, false, BoonType_Guardian, ID_Invigorated_Bulwark);

--- a/ArcDPS Boon Table/Entity.cpp
+++ b/ArcDPS Boon Table/Entity.cpp
@@ -33,12 +33,13 @@ void Entity::applyBoon(cbtevent* ev)
 
 	BoonDef* current_def = getTrackedBoon(ev->skillid);
 	if (!current_def) return;
+	const uint32_t canonical_id = current_def->ids[0];
 
 	auto current_boon_list = in_combat ? &boons_uptime : &boons_uptime_initial;
 
 	std::lock_guard<std::mutex> lock(boons_mtx);
 
-	auto it = current_boon_list->find(ev->skillid);
+	auto it = current_boon_list->find(canonical_id);
 
 	if (it != current_boon_list->end())
 	{
@@ -46,7 +47,7 @@ void Entity::applyBoon(cbtevent* ev)
 	}
 	else
 	{
-		current_boon_list->insert({ current_def->ids[0],Boon(current_def, getBuffApplyDuration(ev)) });
+		current_boon_list->insert({ canonical_id,Boon(current_def, getBuffApplyDuration(ev)) });
 	}
 }
 
@@ -55,7 +56,9 @@ void Entity::removeBoon(cbtevent* ev)
 	if (!ev) return;
 	if (ev->value == 0) return;
 	//	if (ev->value <= ev->overstack_value) return;
-	if (!getTrackedBoon(ev->skillid)) return;
+	BoonDef* current_def = getTrackedBoon(ev->skillid);
+	if (!current_def) return;
+	const uint32_t canonical_id = current_def->ids[0];
 
 	auto current_boon_list = &boons_uptime;
 	if (!in_combat)
@@ -63,7 +66,7 @@ void Entity::removeBoon(cbtevent* ev)
 
 	std::lock_guard<std::mutex> lock(boons_mtx);
 
-	auto it = current_boon_list->find(ev->skillid);
+	auto it = current_boon_list->find(canonical_id);
 
 	if (it != current_boon_list->end())
 	{
@@ -79,12 +82,13 @@ void Entity::gaveBoon(cbtevent* ev)
 
 	BoonDef* current_def = getTrackedBoon(ev->skillid);
 	if (!current_def) return;
+	const uint32_t canonical_id = current_def->ids[0];
 
 	auto current_boon_list = in_combat ? &boons_generation : &boons_generation_initial;
 
 	std::lock_guard<std::mutex> lock(boons_mtx);
 
-	auto it = current_boon_list->find(ev->skillid);
+	auto it = current_boon_list->find(canonical_id);
 
 	if (it != current_boon_list->end())
 	{
@@ -92,7 +96,7 @@ void Entity::gaveBoon(cbtevent* ev)
 	}
 	else
 	{
-		current_boon_list->insert({ current_def->ids[0],Boon(current_def, getBuffApplyDuration(ev)) });
+		current_boon_list->insert({ canonical_id,Boon(current_def, getBuffApplyDuration(ev)) });
 	}
 }
 


### PR DESCRIPTION
## Analysis

The trait-enhanced version of Rite of the Great Dwarf is reported with effect ID `80245`, while the existing tracked definition uses `26596` as its canonical ID. The event handlers inserted state under the canonical ID but looked it up using the raw event ID, so alternate IDs could not update or remove the stored entry.

## Changes

- Add effect ID `80245` to Rite of the Great Dwarf.
- Normalize boon application, removal, and generation lookups to the canonical effect ID.
- Accumulate all alternate IDs in the same boon record.

## Changed files

- `ArcDPS Boon Table/BuffIds.cpp`
- `ArcDPS Boon Table/Entity.cpp`

## Validation

- `git diff --check`
- Verified that the PR contains only the two intended source files.
- The trait-enhanced version was counted correctly in my local in-game test.

Fixes #72